### PR TITLE
Update spark version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dependency-reduced-pom.xml
 build
 __pycache__
 .fleet
+
+databricks.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM openjdk:8-jdk-alpine
+
+# Install Python, Scala, and other dependencies
+RUN apk add --no-cache python3 py3-pip bash
+
+# Install Tesseract
+RUN apk --no-cache add tesseract-ocr
+
+# Install Scala (version based on Databricks runtime)
+ENV SCALA_VERSION 2.12.10
+ENV SCALA_HOME /usr/share/scala
+RUN wget https://downloads.lightbend.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz && \
+    tar xzf scala-$SCALA_VERSION.tgz && \
+    mv scala-$SCALA_VERSION $SCALA_HOME && \
+    rm scala-$SCALA_VERSION.tgz && \
+    ln -s $SCALA_HOME/bin/* /usr/bin/
+
+# Install Spark (version based on Databricks runtime)
+ENV SPARK_VERSION 3.5.0
+ENV SPARK_HOME /usr/local/spark
+RUN wget https://archive.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop3.tgz && \
+    tar -xzf spark-$SPARK_VERSION-bin-hadoop3.tgz && \
+    mv spark-$SPARK_VERSION-bin-hadoop3 $SPARK_HOME && \
+    rm spark-$SPARK_VERSION-bin-hadoop3.tgz
+
+# Install Maven
+ENV MAVEN_VERSION 3.9.6
+ENV MAVEN_HOME /usr/lib/mvn
+RUN wget http://apache.osuosl.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && \
+    tar -zxvf apache-maven-$MAVEN_VERSION-bin.tar.gz && \
+    mv apache-maven-$MAVEN_VERSION /usr/lib/mvn && \
+    rm apache-maven-$MAVEN_VERSION-bin.tar.gz
+ENV PATH $PATH:$SCALA_HOME/bin:$SPARK_HOME/bin:$MAVEN_HOME/bin
+
+# Set work directory
+WORKDIR /app
+
+# Copy the Maven pom.xml and src directory to /app
+COPY pom.xml /app/
+COPY src /app/src
+COPY target /app/target
+
+# Expose the port Spark will use
+EXPOSE 4040
+
+# Optional: Run Maven dependency resolution automatically when the image is built
+RUN mvn dependency:resolve
+
+# Optional: Run Maven package to compile the project when the image is built
+CMD ["mvn", "package"]

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.5.0</spark.version>
-        <java.version>11</java.version>
+        <java.version>8</java.version>
     </properties>
 
     <dependencies>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -360,7 +360,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
-                        <version>3.2.4</version>
+                        <version>3.5.1</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>
@@ -372,7 +372,6 @@
                                         <filter>
                                             <artifact>*:*</artifact>
                                             <excludes>
-                                                <!-- SecurityException: Invalid signature file digest for Manifest main attributes-->
                                                 <exclude>META-INF/*.SF</exclude>
                                                 <exclude>META-INF/*.DSA</exclude>
                                                 <exclude>META-INF/*.RSA</exclude>
@@ -380,8 +379,8 @@
                                         </filter>
                                     </filters>
                                     <transformers>
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
                                     </transformers>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.databricks.labs</groupId>
     <artifactId>tika-ocr</artifactId>
-    <version>0.1.4-SNAPSHOT</version>
+    <version>0.1.5-SNAPSHOT</version>
     <name>tika-ocr</name>
 
     <url>https://github.com/databrickslabs/tika-ocr</url>
@@ -55,9 +55,9 @@
     <properties>
         <minimum.coverage>80</minimum.coverage>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.version>2.12.14</scala.version>
+        <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.3.2</spark.version>
+        <spark.version>3.5.0</spark.version>
         <java.version>11</java.version>
     </properties>
 

--- a/src/main/scala/com/databricks/labs/tika/TikaFileFormat.scala
+++ b/src/main/scala/com/databricks/labs/tika/TikaFileFormat.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.tika
 
-import org.apache.commons.io.IOUtils
+import com.google.common.io.{ByteStreams, Closeables}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce.Job
@@ -14,8 +14,6 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.SerializableConfiguration
 import org.apache.tika.io.TikaInputStream
 
-import java.io.ByteArrayInputStream
-import java.net.URI
 import scala.util.{Failure, Success, Try}
 
 class TikaFileFormat extends FileFormat with DataSourceRegister {
@@ -73,7 +71,7 @@ class TikaFileFormat extends FileFormat with DataSourceRegister {
     file: PartitionedFile => {
 
       // Retrieve file information
-      val path = new Path(file.filePath.toUri)
+      val path = file.toPath
       val fs = path.getFileSystem(hadoopConf_B.value.value)
       val status = fs.getFileStatus(path)
       if (status.getLen > maxLength) {
@@ -91,8 +89,8 @@ class TikaFileFormat extends FileFormat with DataSourceRegister {
       try {
 
         // Fully read file content as a ByteArray
-        val fileContent = IOUtils.toByteArray(inputStream)
-        val tikaInputStream = TikaInputStream.get(new ByteArrayInputStream(fileContent))
+        val fileContent = ByteStreams.toByteArray(inputStream)
+        val tikaInputStream = TikaInputStream.get(fileContent)
 
         // Extract text from binary using Tika
         val tikaContent = TikaExtractor.extract(tikaInputStream, fileName, bufferSize)
@@ -106,7 +104,7 @@ class TikaFileFormat extends FileFormat with DataSourceRegister {
 
       } finally {
 
-        IOUtils.close(inputStream)
+        Closeables.close(inputStream, true)
 
       }
     }

--- a/src/main/scala/com/databricks/labs/tika/TikaFileFormat.scala
+++ b/src/main/scala/com/databricks/labs/tika/TikaFileFormat.scala
@@ -73,7 +73,7 @@ class TikaFileFormat extends FileFormat with DataSourceRegister {
     file: PartitionedFile => {
 
       // Retrieve file information
-      val path = new Path(new URI(file.filePath))
+      val path = new Path(file.filePath.toUri)
       val fs = path.getFileSystem(hadoopConf_B.value.value)
       val status = fs.getFileStatus(path)
       if (status.getLen > maxLength) {


### PR DESCRIPTION
- Replicate Databricks Runtime 14.2 with Docker
- Update `pom.xml` for Databricks Runtime 14.2 compatibility
- Upgrade `PatitionedFile` syntax to leverage spark version 3.5.0 changes